### PR TITLE
Adjusts XYZ to Mol and XYZ File to Mol modules to assume angstrom and convert to bohr

### DIFF
--- a/src/cxx/nux/xyz_to_mol.cpp
+++ b/src/cxx/nux/xyz_to_mol.cpp
@@ -20,6 +20,12 @@
 
 namespace nux {
 
+double ang2bohr(double ang_value) {
+    // Converts a anstrom-based value to a bohr-based value
+    double bohr_value = ang_value * 1.8897259886;
+    return bohr_value;
+}
+
 MODULE_CTOR(XYZToMolecule) {
     satisfies_property_type<simde::MoleculeFromString>();
     add_submodule<simde::ZFromSymbol>("Z from symbol");
@@ -66,9 +72,11 @@ MODULE_RUN(XYZToMolecule) {
 
         auto Z    = z_from_sym.run_as<simde::ZFromSymbol>(atom_string);
         auto atom = atom_from_z.run_as<simde::AtomFromZ>(Z);
-        atom.x()  = x;
-        atom.y()  = y;
-        atom.z()  = z;
+
+        // Assumes that the XYZ coordnates given are in angstroms
+        atom.x() = ang2bohr(x);
+        atom.y() = ang2bohr(y);
+        atom.z() = ang2bohr(z);
 
         mol.push_back(atom);
     }

--- a/tests/cxx/unit_tests/xyz_file_to_mol.cpp
+++ b/tests/cxx/unit_tests/xyz_file_to_mol.cpp
@@ -47,7 +47,7 @@ TEST_CASE("XYZFileToMolecule") {
     SECTION("Full XYZ To Molecule run: File") {
         auto atom0{make_atoms(1)};
         auto atom1{make_atoms(1)};
-        atom1.z() = 1;
+        atom1.z() = 1.8897259886;
 
         simde::type::molecule test_mol{atom0, atom1};
 

--- a/tests/cxx/unit_tests/xyz_file_to_mol.cpp
+++ b/tests/cxx/unit_tests/xyz_file_to_mol.cpp
@@ -47,7 +47,7 @@ TEST_CASE("XYZFileToMolecule") {
     SECTION("Full XYZ To Molecule run: File") {
         auto atom0{make_atoms(1)};
         auto atom1{make_atoms(1)};
-        atom1.z() = 1.8897259886;
+        atom1.z() = 1;
 
         simde::type::molecule test_mol{atom0, atom1};
 

--- a/tests/cxx/unit_tests/xyz_to_mol.cpp
+++ b/tests/cxx/unit_tests/xyz_to_mol.cpp
@@ -51,6 +51,24 @@ TEST_CASE("XYZToMolecule") {
     SECTION("Full XYZ To Molecule run: Data") {
         auto atom0{make_atoms(1)};
         auto atom1{make_atoms(1)};
+        atom1.z() = 1;
+
+        simde::type::molecule test_mol{atom0, atom1};
+
+        std::stringstream xyz_data;
+        xyz_data << "2\n";
+        xyz_data << "This is a comment!\n";
+        xyz_data << "H 0 0 0\n";
+        xyz_data << "H 0 0 1\n";
+
+        auto mol = xyz_mod.run_as<simde::MoleculeFromString>(xyz_data.str());
+
+        REQUIRE(mol == test_mol);
+    }
+
+    SECTION("XYZ to Molecule Unit Scaling: Angstroms to Bohr") {
+        auto atom0{make_atoms(1)};
+        auto atom1{make_atoms(1)};
         atom1.z() = 1.8897259886;
 
         simde::type::molecule test_mol{atom0, atom1};
@@ -60,6 +78,8 @@ TEST_CASE("XYZToMolecule") {
         xyz_data << "This is a comment!\n";
         xyz_data << "H 0 0 0\n";
         xyz_data << "H 0 0 1\n";
+
+        xyz_mod.change_input("Unit scaling factor", 1.8897259886);
 
         auto mol = xyz_mod.run_as<simde::MoleculeFromString>(xyz_data.str());
 

--- a/tests/cxx/unit_tests/xyz_to_mol.cpp
+++ b/tests/cxx/unit_tests/xyz_to_mol.cpp
@@ -51,7 +51,7 @@ TEST_CASE("XYZToMolecule") {
     SECTION("Full XYZ To Molecule run: Data") {
         auto atom0{make_atoms(1)};
         auto atom1{make_atoms(1)};
-        atom1.z() = 1;
+        atom1.z() = 1.8897259886;
 
         simde::type::molecule test_mol{atom0, atom1};
 

--- a/tests/cxx/unit_tests/xyz_to_mol.cpp
+++ b/tests/cxx/unit_tests/xyz_to_mol.cpp
@@ -69,6 +69,8 @@ TEST_CASE("XYZToMolecule") {
     SECTION("XYZ to Molecule Unit Scaling: Angstroms to Bohr") {
         auto atom0{make_atoms(1)};
         auto atom1{make_atoms(1)};
+        atom1.x() = 1.8897259886;
+        atom1.y() = 1.8897259886;
         atom1.z() = 1.8897259886;
 
         simde::type::molecule test_mol{atom0, atom1};
@@ -77,7 +79,7 @@ TEST_CASE("XYZToMolecule") {
         xyz_data << "2\n";
         xyz_data << "This is a comment!\n";
         xyz_data << "H 0 0 0\n";
-        xyz_data << "H 0 0 1\n";
+        xyz_data << "H 1 1 1\n";
 
         xyz_mod.change_input("Unit scaling factor", 1.8897259886);
 


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
No

**Description**
Converts angstrom-based XYZ files to bohr coordinates for Chemist conventions.

**TODOs**
None, r2g.
